### PR TITLE
Use SmallGroupsAddLayer where SmallGrp offers it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ This file describes changes in the `sotgrps` package.
 
 # Unreleased
 
+  - Require GAP 4.12
   - If available, use the `SmallGroupsAddLayer` function provided by `SmallGrp`
 
 # 1.3.1 (2026-07-29)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 This file describes changes in the `sotgrps` package.
 
+# Unreleased
+
+  - Register with the small groups library through `SmallGroupsAddLayer`
+    where `SmallGrp` offers it, instead of filling its arrays by hand. The
+    old route is kept for older `SmallGrp`, where `SOTGRPS_LAYER` and
+    `SOTGRPS_POS` are still bound; with the new one they are not.
+
 # 1.3.1 (2026-07-29)
 
   - Declare `SmallGrp` as a needed package. It always was required, as

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,7 @@ This file describes changes in the `sotgrps` package.
 
 # Unreleased
 
-  - Register with the small groups library through `SmallGroupsAddLayer`
-    where `SmallGrp` offers it; older `SmallGrp` is still supported, and
-    only there are `SOTGRPS_LAYER` and `SOTGRPS_POS` bound.
+  - If available, use the `SmallGroupsAddLayer` function provided by `SmallGrp`
 
 # 1.3.1 (2026-07-29)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,8 @@ This file describes changes in the `sotgrps` package.
 # Unreleased
 
   - Register with the small groups library through `SmallGroupsAddLayer`
-    where `SmallGrp` offers it, instead of filling its arrays by hand. The
-    old route is kept for older `SmallGrp`, where `SOTGRPS_LAYER` and
-    `SOTGRPS_POS` are still bound; with the new one they are not.
+    where `SmallGrp` offers it; older `SmallGrp` is still supported, and
+    only there are `SOTGRPS_LAYER` and `SOTGRPS_POS` bound.
 
 # 1.3.1 (2026-07-29)
 

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -79,7 +79,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.11",
+  GAP := ">=4.12",
   NeededOtherPackages := [["smallgrp", ">=1.3"]],
   SuggestedOtherPackages := [],
   ExternalConditions := [] ),

--- a/gap/Integration.gi
+++ b/gap/Integration.gi
@@ -1,5 +1,42 @@
 ## Integration with SmallGrps
 
+if IsBound(SmallGroupsAddLayer) then
+
+# SmallGrp 1.7 and up: describe the layer and let SmallGrp place it
+SmallGroupsAddLayer( rec(
+    name := "SOTGrps",
+
+    # the orders we cover, and how many groups we have of each
+    available := function( size )
+        if not IsSOTAvailable(size) then
+            return fail;
+        fi;
+        return rec( number := NumberOfSOTGroups(size) );
+    end,
+
+    # Method for SmallGroup(size, i):
+    group := function( size, i, inforec )
+        return SOTGroup(size, i);
+    end,
+
+    # Method for IdGroup(G):
+    id := function( G, inforec )
+        return IdSOTGroup(G)[2];
+    end,
+
+    # Method for SmallGroupsInformation(size):
+    information := function( size, inforec, num )
+        local fac, ind;
+        fac := Collected(Factors(size));
+        SortBy(fac, Reversed);
+        ind := List(fac, x -> x[2]);
+        _SOTGroupsInformation(size, fac, ind);
+        Print("\n");
+    end ) );
+
+else
+
+# SmallGrp before 1.7: claim the slots and fill the arrays by hand
 
 # Get the next available "layer" id (the built-in library
 # consists of 11 layers, but other packages may already have
@@ -68,3 +105,5 @@ SMALL_GROUPS_INFORMATION[ SOTGRPS_POS ] := function( size, inforec, num )
     _SOTGroupsInformation(size, fac, ind);
     Print("\n");
 end;
+
+fi;

--- a/tst/integration.tst
+++ b/tst/integration.tst
@@ -37,7 +37,7 @@ gap> testOrder(13^3*2);
     15 is non-nilpotent and has a normal Sylow 2-subgroup with Sylow 
        13-subgroup [ 2197, 4 ].
 
-  This size belongs to layer 12 of the SmallGroups library. 
+  This size belongs to the layer "SOTGrps". 
   IdSmallGroup is available for this size. 
  
 gap> testOrder(13^3*3);
@@ -60,7 +60,7 @@ gap> testOrder(13^3*3);
     19 is non-nilpotent and has a normal Sylow 3-subgroup with Sylow 
        13-subgroup [ 2197, 4 ].
 
-  This size belongs to layer 12 of the SmallGroups library. 
+  This size belongs to the layer "SOTGrps". 
   IdSmallGroup is available for this size. 
  
 gap> testOrder(13^3*5);
@@ -73,7 +73,7 @@ gap> testOrder(13^3*5);
     4 - 5 are nonabelian nilpotent and have a normal Sylow 13-subgroup and a
         normal Sylow 5-subgroup.
 
-  This size belongs to layer 12 of the SmallGroups library. 
+  This size belongs to the layer "SOTGrps". 
   IdSmallGroup is available for this size. 
  
 gap> testOrder(13^3*7);
@@ -90,7 +90,7 @@ gap> testOrder(13^3*7);
     7 is non-nilpotent and has a normal Sylow 7-subgroup with Sylow 
        13-subgroup [ 2197, 3 ].
 
-  This size belongs to layer 12 of the SmallGroups library. 
+  This size belongs to the layer "SOTGrps". 
   IdSmallGroup is available for this size. 
  
 gap> testOrder(13^3*11);
@@ -103,7 +103,7 @@ gap> testOrder(13^3*11);
     4 - 5 are nonabelian nilpotent and have a normal Sylow 13-subgroup and a
         normal Sylow 11-subgroup.
 
-  This size belongs to layer 12 of the SmallGroups library. 
+  This size belongs to the layer "SOTGrps". 
   IdSmallGroup is available for this size. 
  
 gap> testOrder(37^3*7);
@@ -118,7 +118,7 @@ gap> testOrder(37^3*7);
     6 is non-nilpotent and has a normal Sylow 7-subgroup with Sylow 
        37-subgroup [ 50653, 5 ].
 
-  This size belongs to layer 12 of the SmallGroups library. 
+  This size belongs to the layer "SOTGrps". 
   IdSmallGroup is available for this size. 
  
 

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,5 +1,15 @@
 LoadPackage("SOTGrps");
 ReadPackage("sotgrps", "tst/test.gi");
+
+# The expected output is written for SmallGrp 1.7, which names the layer an
+# order belongs to where older versions numbered it. Drop this once SmallGrp
+# 1.7 is required.
+SOTGRPS_TEST_TRANSFORM := function( str )
+    return ReplacedString( str, "layer 12 of the SmallGroups library",
+                           "the layer \"SOTGrps\"" );
+end;
+
 TestDirectory( DirectoriesPackageLibrary("sotgrps", "tst"), rec(exitGAP := true,
-            testOptions := rec( compareFunction := "uptowhitespace" ) ) );
+            testOptions := rec( compareFunction := "uptowhitespace",
+                                transformFunction := SOTGRPS_TEST_TRANSFORM ) ) );
 FORCE_QUIT_GAP(1);


### PR DESCRIPTION
SmallGrp 1.7 takes a layer as a record and places it itself, so the two slot numbers and the six array assignments are no longer ours to get right. The old route stays for SmallGrp before 1.7, chosen by `IsBound`.

`SOTGRPS_LAYER` and `SOTGRPS_POS` exist only on that old route now; nothing outside `gap/Integration.gi` read them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>